### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,5 +1,8 @@
 name: Development branches
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/bpm-crafters/bpm-crafters-maven-parent/security/code-scanning/3](https://github.com/bpm-crafters/bpm-crafters-maven-parent/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the provided workflow, it primarily checks out code and builds it using Maven, which only requires `contents: read`. No write permissions are necessary.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
