### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -3,6 +3,8 @@ on:
   milestone:
     types: [closed]
 name: Milestone Closure
+permissions:
+  contents: write
 jobs:
   create-release-notes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/bpm-crafters/bpm-crafters-maven-parent/security/code-scanning/2](https://github.com/bpm-crafters/bpm-crafters-maven-parent/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Based on the workflow's actions:
1. The `contents: read` permission is needed to check out the repository code.
2. The `contents: write` permission is required to create a draft release.
3. No other permissions are necessary for this workflow.

The `permissions` block will be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
